### PR TITLE
Llvm 12 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .stack-work
 dist-newstyle
 stack.yaml.lock
+.hie

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: xenial
+dist: bionic
 language: generic
 
 env:
@@ -18,7 +18,7 @@ addons:
       - g++-5
       - libgmp-dev
     sources:
-      - llvm-toolchain-xenial-9
+      - llvm-toolchain-bionic-12
       - ubuntu-toolchain-r-test
 
 before_install:
@@ -28,10 +28,10 @@ before_install:
   - export CC=/usr/bin/$GCC
   - export CXX=/usr/bin/$GXX
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-  - echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" | sudo tee -a /etc/apt/sources.list
+  - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main" | sudo tee -a /etc/apt/sources.list
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/ppa
   - sudo apt-get update
-  - sudo apt-get --yes install llvm-9 llvm-9-dev
+  - sudo apt-get --yes install llvm-12 llvm-12-dev
 
 install:
   - stack --no-terminal --install-ghc test --only-dependencies

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ LLVM from Haskell.
 * [arith](./arith) - a minimal JIT compiler for functions of one (real) variable using recursion schemes
 * [irbuilder](./irbuilder) - Basic usage of the LLVM IRBuilder for constructing modules
 
-These examples require LLVM 9.0. Check that your installed LLVM version is
+These examples require LLVM 12.0. Check that your installed LLVM version is
 precisely 9.0. If not then follow the install directions in the
 [llvm-hs](https://github.com/llvm-hs/llvm-hs) repository.
 
 ```bash
 $ llvm-config --version
-9.0
+12.0
 ```
 
 To run the examples with Stack:
@@ -52,4 +52,4 @@ License
 -------
 
 MIT License
-Copyright (c) 2017-2020, Stephen Diehl
+Copyright (c) 2017-2021, Stephen Diehl

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LLVM from Haskell.
 * [irbuilder](./irbuilder) - Basic usage of the LLVM IRBuilder for constructing modules
 
 These examples require LLVM 12.0. Check that your installed LLVM version is
-precisely 9.0. If not then follow the install directions in the
+correct. If not then follow the install directions in the
 [llvm-hs](https://github.com/llvm-hs/llvm-hs) repository.
 
 ```bash

--- a/arith/Arith.hs
+++ b/arith/Arith.hs
@@ -1,13 +1,8 @@
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-
-module Main where
 
 import Control.DeepSeq (NFData, force)
 import Control.Exception
@@ -17,10 +12,8 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import Data.Foldable
 import Data.Functor.Foldable hiding (fold)
-import Data.IORef
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Monoid
 import qualified Data.Set as Set
 import Data.Text.Lazy (Text)
 import qualified Data.Text.Lazy.IO as Text
@@ -38,7 +31,8 @@ import qualified LLVM.IRBuilder.Monad as LLVMIR
 import qualified LLVM.Internal.OrcJIT as JIT
 import qualified LLVM.Linking as JIT
 import qualified LLVM.Module as JIT
-import qualified LLVM.OrcJIT as JIT
+import qualified LLVM.PassManager as PM
+--import qualified LLVM.OrcJIT as JIT
 import qualified LLVM.Pretty as LLVMPretty
 import qualified LLVM.Relocation as Reloc
 import qualified LLVM.Target as JIT
@@ -181,10 +175,11 @@ ppExpAlg (Cos (_, a)) = function "cos" a
 ppExpAlg Var = "x"
 
 paren :: Bool -> String -> String
-paren b x
-  | b = "(" ++ x ++ ")"
-  | otherwise = x
+paren b e
+  | b = "(" ++ e ++ ")"
+  | otherwise = e
 
+function :: String -> String -> String
 function name arg =
   name ++ paren True arg
 
@@ -209,10 +204,10 @@ isVar _ = False
 -- | Evaluate an 'Expr'ession using standard
 --   'Num', 'Fractional' and 'Floating' operations.
 eval :: Expr -> (Double -> Double)
-eval fexpr x = cata alg fexpr
+eval fexpr v = cata alg fexpr
   where
     alg e = case e of
-      Var -> x
+      Var -> v
       Lit d -> d
       Add a b -> a + b
       Sub a b -> a - b
@@ -244,12 +239,12 @@ declarePrimitives ::
 declarePrimitives expr = fmap Map.fromList
   $ forM primitives
   $ \primName -> do
-    f <-
+    fn <-
       LLVMIR.extern
         (LLVM.mkName ("llvm." <> primName <> ".f64"))
         [LLVM.double]
         LLVM.double
-    return (primName, f)
+    return (primName, fn)
   where
     primitives = Set.toList (cata alg expr)
     alg (Exp ps) = Set.insert "exp" ps
@@ -261,7 +256,7 @@ declarePrimitives expr = fmap Map.fromList
 
 -- | Generate an LLVM IR module for the given expression,
 --   including @declare@ statements for the intrinsics and
---   a function, always called @f@, that will perform the copoutations
+--   a function, always called @f@, that will perform the cmoputations
 --   described by the 'Expr'ession.
 codegen :: Expr -> LLVM.Module
 codegen fexpr = LLVMIR.buildModule "arith.ll" $ do
@@ -271,21 +266,21 @@ codegen fexpr = LLVMIR.buildModule "arith.ll" $ do
     LLVMIR.ret res
   return ()
   where
-    alg arg _ (Lit d) =
+    alg _   _ (Lit d) =
       return (LLVM.ConstantOperand $ LLVM.Float $ LLVM.Double d)
     alg arg _ Var = return arg
-    alg arg _ (Add a b) = LLVMIR.fadd a b `LLVMIR.named` "x"
-    alg arg _ (Sub a b) = LLVMIR.fsub a b `LLVMIR.named` "x"
-    alg arg _ (Mul a b) = LLVMIR.fmul a b `LLVMIR.named` "x"
-    alg arg _ (Div a b) = LLVMIR.fdiv a b `LLVMIR.named` "x"
+    alg _   _ (Add a b) = LLVMIR.fadd a b `LLVMIR.named` "x"
+    alg _   _ (Sub a b) = LLVMIR.fsub a b `LLVMIR.named` "x"
+    alg _   _ (Mul a b) = LLVMIR.fmul a b `LLVMIR.named` "x"
+    alg _   _ (Div a b) = LLVMIR.fdiv a b `LLVMIR.named` "x"
     alg arg ps (Neg a) = do
       z <- alg arg ps (Lit 0)
       LLVMIR.fsub z a `LLVMIR.named` "x"
-    alg arg ps (Exp a) = callDblfun (ps Map.! "exp") a `LLVMIR.named` "x"
-    alg arg ps (Log a) = callDblfun (ps Map.! "log") a `LLVMIR.named` "x"
-    alg arg ps (Sqrt a) = callDblfun (ps Map.! "sqrt") a `LLVMIR.named` "x"
-    alg arg ps (Sin a) = callDblfun (ps Map.! "sin") a `LLVMIR.named` "x"
-    alg arg ps (Cos a) = callDblfun (ps Map.! "cos") a `LLVMIR.named` "x"
+    alg _   ps (Exp a) = callDblfun (ps Map.! "exp") a `LLVMIR.named` "x"
+    alg _   ps (Log a) = callDblfun (ps Map.! "log") a `LLVMIR.named` "x"
+    alg _   ps (Sqrt a) = callDblfun (ps Map.! "sqrt") a `LLVMIR.named` "x"
+    alg _   ps (Sin a) = callDblfun (ps Map.! "sin") a `LLVMIR.named` "x"
+    alg _   ps (Cos a) = callDblfun (ps Map.! "cos") a `LLVMIR.named` "x"
 
 codegenText :: Expr -> Text
 codegenText = LLVMPretty.ppllvm . codegen
@@ -298,51 +293,68 @@ printCodegen = Text.putStrLn . codegenText
 -- | This allows us to call dynamically loaded functions
 foreign import ccall "dynamic"
   mkDoubleFun :: FunPtr (Double -> Double) -> (Double -> Double)
-
+{-
 resolver ::
   JIT.IRCompileLayer l ->
   JIT.MangledSymbol ->
   IO (Either JIT.JITSymbolError JIT.JITSymbol)
 resolver compileLayer symbol =
   JIT.findSymbol compileLayer symbol True
+-}
 
 symbolFromProcess :: JIT.MangledSymbol -> IO JIT.JITSymbol
 symbolFromProcess sym =
   (\addr -> JIT.JITSymbol addr JIT.defaultJITSymbolFlags)
     <$> JIT.getSymbolAddressInProcess sym
 
-resolv :: JIT.IRCompileLayer l -> JIT.SymbolResolver
-resolv cl = JIT.SymbolResolver (\sym -> JIT.findSymbol cl sym True)
-
 printIR :: MonadIO m => ByteString -> m ()
 printIR = liftIO . BS.putStrLn . ("\n*** LLVM IR ***\n\n" <>)
+
+passes :: PM.PassSetSpec
+passes = PM.defaultCuratedPassSetSpec {PM.optLevel = Just 3}
 
 -- | JIT-compile the given 'Expr'ession and use the resulting function.
 withSimpleJIT ::
   NFData a =>
   Expr ->
-  -- | what to do with the generated functiion
+  -- | what to do with the generated function
   ((Double -> Double) -> a) ->
   IO a
 withSimpleJIT expr doFun = do
-  resolvers <- newIORef Map.empty
+  putStrLn "*** Codegen ***"
+  printCodegen expr
   JIT.withContext $ \context -> (>>) (JIT.loadLibraryPermanently Nothing)
-    $ JIT.withModuleFromAST context (codegen expr)
-    $ \mod' ->
+    $ JIT.withModuleFromAST context (codegen expr) $ \mod' ->
       JIT.withHostTargetMachine Reloc.PIC CodeModel.Default CodeGenOpt.Default $ \tm ->
-        JIT.withExecutionSession $ \es ->
-          JIT.withObjectLinkingLayer es (\k -> fmap (\rs -> rs Map.! k) (readIORef resolvers)) $ \objectLayer ->
-            JIT.withIRCompileLayer objectLayer tm $ \compileLayer -> do
-              asm <- JIT.moduleLLVMAssembly mod'
-              printExpr expr
-              printIR asm
-              JIT.withModuleKey es $ \k ->
-                JIT.withModule compileLayer k mod' $ do
-                  fSymbol <- JIT.mangleSymbol compileLayer "f"
-                  Right (JIT.JITSymbol fnAddr _) <- JIT.findSymbol compileLayer fSymbol True
-                  let f = mkDoubleFun . castPtrToFunPtr $ wordPtrToPtr fnAddr
-                  liftIO (putStrLn "*** Result ***\n")
-                  evaluate $ force (doFun f)
+        JIT.withExecutionSession $ \es -> do
+
+          let dylibName = "myDylib"
+          dylib <- JIT.createJITDylib es dylibName
+
+          JIT.withClonedThreadSafeModule mod' $ \tsm -> do
+            objectLayer <- JIT.createRTDyldObjectLinkingLayer es
+            compileLayer <- JIT.createIRCompileLayer es objectLayer tm
+            JIT.addDynamicLibrarySearchGeneratorForCurrentProcess compileLayer dylib
+            JIT.addModule tsm dylib compileLayer
+
+            asm <- JIT.moduleLLVMAssembly mod'
+            printExpr expr
+            printIR asm
+
+            optimized <- PM.withPassManager passes $ flip PM.runPassManager mod'
+            when optimized $ putStrLn "*** Optimized ***"
+            optasm <- JIT.moduleLLVMAssembly mod'
+            printIR optasm
+
+            sym <- JIT.lookupSymbol es compileLayer dylib "f"
+            case sym of
+              Left (JIT.JITSymbolError err) -> do
+                print err
+                error "Execution aborted"
+              Right (JIT.JITSymbol fnAddr _) -> do
+                let fn =  mkDoubleFun . castPtrToFunPtr $ wordPtrToPtr fnAddr
+                liftIO (putStrLn "*** Result ***\n")
+                evaluate $ force (doFun fn)
 
 -- * Utilities
 
@@ -358,7 +370,7 @@ cataM alg = c
 -- * Main
 
 f :: Floating a => a -> a
-f t = sin (pi * t / 2) * (1 + sqrt t) ^ 2
+f t = sin (pi * t / 2) * (1 + sqrt t) ^ (2 :: Int)
 
 main :: IO ()
 main = do

--- a/arith/Arith.hs
+++ b/arith/Arith.hs
@@ -35,7 +35,7 @@ import qualified LLVM.Context as JIT
 import qualified LLVM.IRBuilder.Instruction as LLVMIR
 import qualified LLVM.IRBuilder.Module as LLVMIR
 import qualified LLVM.IRBuilder.Monad as LLVMIR
-import qualified LLVM.Internal.OrcJIT.CompileLayer as JIT
+import qualified LLVM.Internal.OrcJIT as JIT
 import qualified LLVM.Linking as JIT
 import qualified LLVM.Module as JIT
 import qualified LLVM.OrcJIT as JIT

--- a/basic/Main.hs
+++ b/basic/Main.hs
@@ -1,14 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Main where
-
 import LLVM.AST
 import qualified LLVM.AST as AST
 import LLVM.AST.Global
 import LLVM.Context
 import LLVM.Module
 
-import Control.Monad.Except
 import Data.ByteString.Char8 as BS
 
 int :: Type
@@ -44,8 +41,8 @@ module_ = defaultModule
 
 
 toLLVM :: AST.Module -> IO ()
-toLLVM mod = withContext $ \ctx -> do
-  llvm <- withModuleFromAST ctx mod moduleLLVMAssembly
+toLLVM modul = withContext $ \ctx -> do
+  llvm <- withModuleFromAST ctx modul moduleLLVMAssembly
   BS.putStrLn llvm
 
 

--- a/examples.cabal
+++ b/examples.cabal
@@ -20,32 +20,32 @@ executable basic
   main-is:        Main.hs
   hs-source-dirs: basic
   build-depends:
-      base          >=4.7   && <4.14
+      base          >=4.7   && <4.15
     , bytestring    >=0.10  && <0.11
-    , llvm-hs       >=9.0   && <9.1
-    , llvm-hs-pure  >=9.0   && <9.1
+    , llvm-hs       >=9.0   && <13.0
+    , llvm-hs-pure  >=9.0   && <13.0
     , mtl           >=2.2.2 && <2.3
 
 executable orc
   main-is:        Main.hs
   hs-source-dirs: orc
   build-depends:
-      base          >=4.7   && <4.14
+      base          >=4.7   && <4.15
     , bytestring    >=0.10  && <0.11
     , containers    >=0.6   && <0.7
-    , llvm-hs       >=9.0   && <9.1
-    , llvm-hs-pure  >=9.0   && <9.1
+    , llvm-hs       >=9.0   && <13.0
+    , llvm-hs-pure  >=9.0   && <13.0
     , mtl           >=2.2.2 && <2.3
 
 executable irbuilder
   main-is:        Main.hs
   hs-source-dirs: irbuilder
   build-depends:
-      base            >=4.7   && <4.14
+      base            >=4.7   && <4.15
     , bytestring      >=0.10  && <0.11
-    , llvm-hs         >=9.0   && <9.1
-    , llvm-hs-pretty  >=0.9   && <0.10
-    , llvm-hs-pure    >=9.0   && <9.1
+    , llvm-hs         >=9.0   && <13.0
+    , llvm-hs-pretty  >=0.9   && <13.0
+    , llvm-hs-pure    >=9.0   && <13.0
     , mtl             >=2.2.2 && <2.3
     , text            >=1.2   && <1.3
 
@@ -53,13 +53,13 @@ executable arith
   main-is:        Arith.hs
   hs-source-dirs: arith
   build-depends:
-      base               >=4.7   && <4.14
+      base               >=4.7   && <4.15
     , bytestring         >=0.10  && <0.11
     , containers         >=0.6   && <0.7
     , deepseq            >=1.4   && <1.5
-    , llvm-hs            >=9.0   && <9.1
-    , llvm-hs-pretty     >=0.9   && <0.10
-    , llvm-hs-pure       >=9.0   && <9.1
+    , llvm-hs            >=9.0   && <13.0
+    , llvm-hs-pretty     >=0.9   && <13.0
+    , llvm-hs-pure       >=9.0   && <13.0
     , mtl                >=2.2.2 && <2.3
     , recursion-schemes  >=5.1   && <5.2
     , text               >=1.2   && <1.3

--- a/examples.cabal
+++ b/examples.cabal
@@ -17,7 +17,7 @@ source-repository head
 
 common common-options
   build-depends:
-    , base          >=4.7  && <4.15
+    , base          >=4.7  && <4.16
     , llvm-hs-pure  >=12.0 && <13.0
 
   ghc-options:

--- a/examples.cabal
+++ b/examples.cabal
@@ -17,8 +17,8 @@ source-repository head
 
 common common-options
   build-depends:
-    , base          >=4.7   && <4.15
-    , llvm-hs-pure  >=12.0   && <13.0
+    , base          >=4.7  && <4.15
+    , llvm-hs-pure  >=12.0 && <13.0
 
   ghc-options:
     -Wall -Wcompat -Widentities -Wincomplete-uni-patterns
@@ -44,24 +44,24 @@ executable basic
   main-is:        Main.hs
   hs-source-dirs: basic
   build-depends:
-    , bytestring    ^>=0.10
-    , llvm-hs       >=12.0   && <13.0
+    , bytestring  ^>=0.10
+    , llvm-hs     >=12.0 && <13.0
 
 executable orc
   import:         common-options
   main-is:        Main.hs
   hs-source-dirs: orc
   build-depends:
-    , bytestring    ^>=0.10
-    , llvm-hs       >=12.0   && <13.0
-    , mtl           ^>=2.2
+    , bytestring  ^>=0.10
+    , llvm-hs     >=12.0 && <13.0
+    , mtl         ^>=2.2
 
 executable irbuilder
   import:         common-options
   main-is:        Main.hs
   hs-source-dirs: irbuilder
   build-depends:
-    , bytestring    ^>=0.10
+    , bytestring      ^>=0.10
     , llvm-hs-pretty  >=12.0 && <13.0
     , text            ^>=1.2
 
@@ -70,11 +70,10 @@ executable arith
   main-is:        Arith.hs
   hs-source-dirs: arith
   build-depends:
-    , bytestring    ^>=0.10
+    , bytestring         ^>=0.10
     , containers         ^>=0.6
     , deepseq            ^>=1.4
+    , llvm-hs            >=12.0 && <13.0
+    , llvm-hs-pretty     >=12.0 && <13.0
     , recursion-schemes  ^>=5.1
-    , llvm-hs       >=12.0   && <13.0
-    , mtl           ^>=2.2
     , text               ^>=1.2
-    , transformers       ^>=0.5

--- a/examples.cabal
+++ b/examples.cabal
@@ -1,66 +1,80 @@
-name:          examples
-version:       1.0.0.0
-license:       MIT
-license-file:  LICENSE
-cabal-version: >=1.8
-tested-with:   GHC >=7.8
-build-type:    Simple
-maintainer:    Stephen Diehl`
-category:      Compilers
-synopsis:      Examples for the llvm-hs library
-description:   Examples using the llvm-hs library
-extra-source-files:
-  README.md
+cabal-version:      2.4
+name:               examples
+version:            1.0.1.0
+license:            MIT
+license-file:       LICENSE
+tested-with:        GHC >=7.8
+build-type:         Simple
+maintainer:         Stephen Diehl`
+category:           Compilers
+synopsis:           Examples for the llvm-hs library
+description:        Examples using the llvm-hs library
+extra-source-files: README.md
 
-Source-Repository head
-    type: git
-    location: git@github.com:llvm-hs/llvm-hs-examples.git
+source-repository head
+  type:     git
+  location: git@github.com:llvm-hs/llvm-hs-examples.git
+
+common common-options
+  build-depends:
+    , base          >=4.7   && <4.15
+    , llvm-hs-pure  >=12.0   && <13.0
+
+  ghc-options:
+    -Wall -Wcompat -Widentities -Wincomplete-uni-patterns
+    -Wincomplete-record-updates -Wredundant-constraints
+    -Wnoncanonical-monad-instances
+
+  if impl(ghc >=8.2)
+    ghc-options: -fhide-source-paths
+
+  if impl(ghc >=8.4)
+    ghc-options: -Wmissing-export-lists -Wpartial-fields
+
+  if impl(ghc >=8.8)
+    ghc-options: -Wmissing-deriving-strategies -fwrite-ide-info -hiedir=.hie
+
+  if impl(ghc >=8.10)
+    ghc-options: -Wunused-packages
+
+  default-language: Haskell2010
 
 executable basic
+  import:         common-options
   main-is:        Main.hs
   hs-source-dirs: basic
   build-depends:
-      base          >=4.7   && <4.15
-    , bytestring    >=0.10  && <0.11
-    , llvm-hs       >=9.0   && <13.0
-    , llvm-hs-pure  >=9.0   && <13.0
-    , mtl           >=2.2.2 && <2.3
+    , bytestring    ^>=0.10
+    , llvm-hs       >=12.0   && <13.0
 
 executable orc
+  import:         common-options
   main-is:        Main.hs
   hs-source-dirs: orc
   build-depends:
-      base          >=4.7   && <4.15
-    , bytestring    >=0.10  && <0.11
-    , containers    >=0.6   && <0.7
-    , llvm-hs       >=9.0   && <13.0
-    , llvm-hs-pure  >=9.0   && <13.0
-    , mtl           >=2.2.2 && <2.3
+    , bytestring    ^>=0.10
+    , llvm-hs       >=12.0   && <13.0
+    , mtl           ^>=2.2
 
 executable irbuilder
+  import:         common-options
   main-is:        Main.hs
   hs-source-dirs: irbuilder
   build-depends:
-      base            >=4.7   && <4.15
-    , bytestring      >=0.10  && <0.11
-    , llvm-hs         >=9.0   && <13.0
-    , llvm-hs-pretty  >=0.9   && <13.0
-    , llvm-hs-pure    >=9.0   && <13.0
-    , mtl             >=2.2.2 && <2.3
-    , text            >=1.2   && <1.3
+    , bytestring    ^>=0.10
+    , llvm-hs-pretty  >=12.0 && <13.0
+    , text            ^>=1.2
 
 executable arith
+  import:         common-options
   main-is:        Arith.hs
   hs-source-dirs: arith
   build-depends:
-      base               >=4.7   && <4.15
-    , bytestring         >=0.10  && <0.11
-    , containers         >=0.6   && <0.7
-    , deepseq            >=1.4   && <1.5
-    , llvm-hs            >=9.0   && <13.0
-    , llvm-hs-pretty     >=0.9   && <13.0
-    , llvm-hs-pure       >=9.0   && <13.0
-    , mtl                >=2.2.2 && <2.3
-    , recursion-schemes  >=5.1   && <5.2
-    , text               >=1.2   && <1.3
-    , transformers       >=0.5   && <0.6
+    , bytestring    ^>=0.10
+    , containers         ^>=0.6
+    , deepseq            ^>=1.4
+    , recursion-schemes  ^>=5.1
+    , llvm-hs       >=12.0   && <13.0
+    , mtl           ^>=2.2
+    , text               ^>=1.2
+    , transformers       ^>=0.5

--- a/examples.cabal
+++ b/examples.cabal
@@ -44,7 +44,7 @@ executable basic
   main-is:        Main.hs
   hs-source-dirs: basic
   build-depends:
-    , bytestring  ^>=0.10
+    , bytestring  ^>=0.11
     , llvm-hs     >=12.0 && <13.0
 
 executable orc
@@ -52,7 +52,7 @@ executable orc
   main-is:        Main.hs
   hs-source-dirs: orc
   build-depends:
-    , bytestring  ^>=0.10
+    , bytestring  ^>=0.11
     , llvm-hs     >=12.0 && <13.0
     , mtl         ^>=2.2
 
@@ -61,7 +61,7 @@ executable irbuilder
   main-is:        Main.hs
   hs-source-dirs: irbuilder
   build-depends:
-    , bytestring      ^>=0.10
+    , bytestring      ^>=0.11
     , llvm-hs-pretty  >=12.0 && <13.0
     , text            ^>=1.2
 
@@ -70,10 +70,11 @@ executable arith
   main-is:        Arith.hs
   hs-source-dirs: arith
   build-depends:
-    , bytestring         ^>=0.10
+    , bytestring         ^>=0.11
     , containers         ^>=0.6
+    , data-fix           ^>=0.3
     , deepseq            ^>=1.4
     , llvm-hs            >=12.0 && <13.0
     , llvm-hs-pretty     >=12.0 && <13.0
-    , recursion-schemes  ^>=5.1
+    , recursion-schemes  ^>=5.2
     , text               ^>=1.2

--- a/irbuilder/Main.hs
+++ b/irbuilder/Main.hs
@@ -15,6 +15,8 @@ import LLVM.IRBuilder.Module
 import LLVM.IRBuilder.Monad
 import LLVM.IRBuilder.Instruction
 
+import LLVM.Pretty (ppllvm)
+
 simple :: Module
 simple = buildModule "exampleModule" $ mdo
   function "f" [(AST.i32, "a")] AST.i32 $ \[a] -> mdo
@@ -37,4 +39,4 @@ simple = buildModule "exampleModule" $ mdo
     ret r
 
 main :: IO ()
-main = print simple
+main = T.putStrLn (ppllvm simple)

--- a/irbuilder/Main.hs
+++ b/irbuilder/Main.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module Main where
 
 import Data.Text.Lazy.IO as T
 
 import LLVM.AST hiding (function)
 import LLVM.AST.Type as AST
-import qualified LLVM.AST.Float as F
+--import qualified LLVM.AST.Float as F
 import qualified LLVM.AST.Constant as C
 import qualified LLVM.AST.IntegerPredicate as P
 
@@ -19,7 +18,7 @@ import LLVM.Pretty (ppllvm)
 
 simple :: Module
 simple = buildModule "exampleModule" $ mdo
-  function "f" [(AST.i32, "a")] AST.i32 $ \[a] -> mdo
+  _function <- function "f" [(AST.i32, "a")] AST.i32 $ \[a] -> mdo
     _entry <- block `named` "entry"
     cond <- icmp P.EQ a (ConstantOperand (C.Int 32 0))
     condBr cond ifThen ifElse
@@ -39,4 +38,6 @@ simple = buildModule "exampleModule" $ mdo
     ret r
 
 main :: IO ()
-main = T.putStrLn (ppllvm simple)
+main = do
+  T.putStrLn (ppllvm simple)
+  print simple

--- a/orc/Main.hs
+++ b/orc/Main.hs
@@ -2,13 +2,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -Wall #-}
 
-module Main where
-
 import Control.Monad.Except
 import qualified Data.ByteString.Char8 as BS
-import Data.IORef
 import Data.Int
-import qualified Data.Map.Strict as Map
 import Foreign.Ptr
 import LLVM.AST
 import qualified LLVM.AST as AST
@@ -17,9 +13,9 @@ import LLVM.AST.Global
 import LLVM.CodeGenOpt
 import LLVM.CodeModel
 import LLVM.Context
-import LLVM.Internal.OrcJIT.CompileLayer
 import LLVM.Module
 import LLVM.OrcJIT
+import LLVM.PassManager
 import LLVM.Relocation
 import LLVM.Target
 import Prelude hiding (mod)
@@ -49,43 +45,51 @@ defAdd =
 module_ :: AST.Module
 module_ =
   defaultModule
-    { moduleName = "basic",
+    { moduleName = "orc",
       moduleDefinitions = [defAdd]
     }
 
 withTestModule :: AST.Module -> (LLVM.Module.Module -> IO a) -> IO a
 withTestModule mod f = withContext $ \context -> withModuleFromAST context mod f
 
-resolver :: CompileLayer l => l -> MangledSymbol -> IO (Either JITSymbolError JITSymbol)
-resolver compileLayer symbol = findSymbol compileLayer symbol True
-
 failInIO :: ExceptT String IO a -> IO a
 failInIO = either fail return <=< runExceptT
 
+passes :: PassSetSpec
+passes = defaultCuratedPassSetSpec {optLevel = Just 3}
+
 eagerJit :: AST.Module -> IO ()
 eagerJit amod = do
-  resolvers <- newIORef Map.empty
-  withTestModule amod $ \mod ->
+  withTestModule amod $ \mod -> do
+
+    putStrLn "Original Module Assembly:"
+    asm <- moduleLLVMAssembly mod
+    BS.putStrLn asm
+
+    optimized <- withPassManager passes $ flip runPassManager mod
+    when optimized $ putStrLn "Optimized:"
+    optasm <- moduleLLVMAssembly mod
+    BS.putStrLn optasm
+
     withHostTargetMachine PIC LLVM.CodeModel.Default LLVM.CodeGenOpt.Default $ \tm ->
-      withExecutionSession $ \es ->
-        withObjectLinkingLayer es (\k -> fmap (\rs -> rs Map.! k) (readIORef resolvers)) $ \linkingLayer ->
-          withIRCompileLayer linkingLayer tm $ \compileLayer -> do
-            mainSymbol <- mangleSymbol compileLayer "add"
-            asm <- moduleLLVMAssembly mod
-            BS.putStrLn asm
-            withModuleKey es $ \k ->
-              withSymbolResolver es (SymbolResolver (resolver compileLayer)) $ \sresolver -> do
-                modifyIORef' resolvers (Map.insert k sresolver)
-                rsym <- findSymbol compileLayer mainSymbol True
-                case rsym of
-                  Left err -> do
-                    print err
-                  Right (JITSymbol mainFn _) -> do
-                    result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
-                    print result
+      withExecutionSession $ \es -> do
+        let dylibName = "myDylib"
+        dylib <- createJITDylib es dylibName
+        withClonedThreadSafeModule mod $ \tsm -> do
+          ol <- createRTDyldObjectLinkingLayer es
+          il <- createIRCompileLayer es ol tm
+          addModule tsm dylib il
+          sym <- lookupSymbol es il dylib "add"
+          case sym of
+            Left (JITSymbolError err) -> do
+              print err
+            Right (JITSymbol mainFn _) -> do
+              result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
+              putStr "Eager JIT Result: "
+              print result
+
 
 main :: IO ()
 main = do
-  res <- eagerJit module_
-  putStrLn "Eager JIT Result:"
-  print res
+  _res <- eagerJit module_
+  return ()


### PR DESCRIPTION
This PR updates the examples for llvm-12. 

The only example that doesn't fully work is `arith`, which segfaults when the JIT'd function `f` is evaluated.  Not clear why, but presumably because the external references to `sin` etc are not properly resolved.  Suggestions welcome.