### PR TITLE
fixed orc example, fixed part of arith example

### DIFF
--- a/orc/Main.hs
+++ b/orc/Main.hs
@@ -76,13 +76,14 @@ eagerJit amod = do
             withModuleKey es $ \k ->
               withSymbolResolver es (SymbolResolver (resolver compileLayer)) $ \sresolver -> do
                 modifyIORef' resolvers (Map.insert k sresolver)
-                rsym <- findSymbol compileLayer mainSymbol True
-                case rsym of
-                  Left err -> do
-                    print err
-                  Right (JITSymbol mainFn _) -> do
-                    result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
-                    print result
+                withModule compileLayer k mod $ do
+                  rsym <- findSymbol compileLayer mainSymbol True
+                  case rsym of
+                    Left err -> do
+                      print err
+                    Right (JITSymbol mainFn _) -> do
+                      result <- mkMain (castPtrToFunPtr (wordPtrToPtr mainFn))
+                      print result
 
 main :: IO ()
 main = do


### PR DESCRIPTION
This PR fixes parts of #13 

I ran across the same problem when trying to run the ORC and Arith examples, so I took a deep dive into LLVM and found out the following:

## ORC
This example was simply missing the registration of the module, ie. the call to `withModule`. Therefore, the `add` symbol could not be found (that llvm-hs simply returns a `JITSymbolError ""` without any message is a bug imo, I'm going to report that right after).

## Arith
In this example, the symbol resolver was not registered and added to the resolver map. Therefore, an error was thrown in the call to `withModule`, which needs a resolver. However, this example still does not work (can't find the symbol); the problem lies somewhere in the module definition (I tried executing the module with the `eagerJit` function from ORC, and that didn't work either); I haven't been able to look into that more.